### PR TITLE
basic plugin folder support

### DIFF
--- a/XG.Application/Program.cs
+++ b/XG.Application/Program.cs
@@ -178,6 +178,8 @@ namespace XG.Application
 
 			app = new App();
 
+			Plugins.Load(app);
+
 			app.AddPlugin(new Plugin.Irc.Plugin());
 			if (Settings.Default.UseJabberClient)
 			{

--- a/XG.Application/XG.Application.csproj
+++ b/XG.Application/XG.Application.csproj
@@ -49,6 +49,7 @@
     <Reference Include="Quartz">
       <HintPath>..\packages\Quartz.2.2.3\lib\net40\Quartz.dll</HintPath>
     </Reference>
+    <Reference Include="System.ComponentModel.Composition" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />

--- a/XG.Business/IEnumerableExtensions.cs
+++ b/XG.Business/IEnumerableExtensions.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using XG.Plugin;
+
+namespace XG.Business
+{
+	public static class IEnumerableExtensions
+	{
+		public static void StartRunAll(this IEnumerable<Lazy<IPlugin, IPluginMetaData>> Plugins)
+		{
+			foreach(var plugin in Plugins)
+			{
+				plugin.Value.StartRun();
+			}
+		}
+		public static void StopRunAll(this IEnumerable<Lazy<IPlugin, IPluginMetaData>> Plugins)
+		{
+			foreach(var plugin in Plugins)
+			{
+				plugin.Value.StopRun();
+			}
+		}
+	}
+}
+

--- a/XG.Business/Plugins.cs
+++ b/XG.Business/Plugins.cs
@@ -23,7 +23,12 @@
 //  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 //  
 
+using System;
+using System.IO;
+using System.ComponentModel.Composition;
+using System.ComponentModel.Composition.Hosting;
 using System.Collections.Generic;
+using XG.Config.Properties;
 using XG.Plugin;
 
 namespace XG.Business
@@ -37,6 +42,43 @@ namespace XG.Business
 		#endregion
 
 		#region FUNCTIONS
+
+		/// <summary>
+		/// Loads the plugins, from the plugins directory
+		/// </summary>
+		/// <remarks>
+		/// uses System.ComponentModel.Composition to do all the heavy lifting.
+		/// </remarks>
+		public static void Load(App obj)
+		{
+			var pluginsDirectoryInfo = new DirectoryInfo(Settings.Default.GetAppDataPath () + "plugins");
+			if(!pluginsDirectoryInfo.Exists)
+			{
+				try
+				{
+					pluginsDirectoryInfo.Create();
+				}
+				catch(Exception ex)
+				{
+					Console.Write(ex.Message);
+				}
+			}
+
+			var catalog = new AggregateCatalog();
+			//catalog.Catalogs.Add(new AssemblyCatalog(typeof(App).Assembly));
+			catalog.Catalogs.Add(new DirectoryCatalog(pluginsDirectoryInfo.ToString()));
+
+			var container = new CompositionContainer(catalog);
+
+			try
+			{
+				container.ComposeParts(obj);
+			}
+			catch(CompositionException ex)
+			{
+				Console.Write(ex.Message);
+			}
+		}
 
 		public Plugins()
 		{

--- a/XG.Business/XG.Business.csproj
+++ b/XG.Business/XG.Business.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Job\Rrd.cs" />
     <Compile Include="Plugins.cs" />
     <Compile Include="Job\SearchUpdater.cs" />
+    <Compile Include="IEnumerableExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\XG.Config\XG.Config.csproj">

--- a/XG.Business/XG.Business.csproj
+++ b/XG.Business/XG.Business.csproj
@@ -11,6 +11,8 @@
     <AssemblyName>XG.Business</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <ProductVersion>12.0.0</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -44,6 +46,7 @@
     <Reference Include="Quartz">
       <HintPath>..\packages\Quartz.2.2.3\lib\net40\Quartz.dll</HintPath>
     </Reference>
+    <Reference Include="System.ComponentModel.Composition" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="App.cs" />

--- a/XG.Plugin/IPlugin.cs
+++ b/XG.Plugin/IPlugin.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Configuration;
+
+namespace XG.Plugin
+{
+	public interface IPlugin
+	{
+		void StartRun();
+		void StopRun();
+	}
+}

--- a/XG.Plugin/IPluginMetaData.cs
+++ b/XG.Plugin/IPluginMetaData.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace XG.Plugin
+{
+	public interface IPluginMetaData
+	{
+		string Name { get; }
+		string Description { get; }
+		//string Version { get; }
+		string Author { get; }
+		string Website { get; }
+	}
+	public static class PluginMetaData
+	{
+		public const string NAME = "Name";
+		public const string DESCRIPTION = "Description";
+		//public const string VERSION = "Version";
+		public const string AUTHOR = "Author";
+		public const string WEBSITE = "Website";
+	}
+}
+

--- a/XG.Plugin/XG.Plugin.csproj
+++ b/XG.Plugin/XG.Plugin.csproj
@@ -49,6 +49,8 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="APlugin.cs" />
     <Compile Include="JobItem.cs" />
+    <Compile Include="IPlugin.cs" />
+    <Compile Include="IPluginMetaData.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\XG.Model\XG.Model.csproj">


### PR DESCRIPTION
I've created basic plugin folder support.
This loads the plugins into the app:

``` C#
Plugins.Load(app);
```

This is all that is needed to make a plugin, just drop the dll into the %AppDataPath%/plugins folder.

``` C#
[Export(typeof(IPlugin))]
[ExportMetadata("Name", "Download History")]
[ExportMetadata("Description", "The quick fox jumped over the lazy dog.")]
//[ExportMetadata("Version", "1.0.0")]
[ExportMetadata("Author", "John Smith")]
[ExportMetadata("Website", "https://example.com/")] 
class MyPlugin : IPlugin
{
        void StartRun(){}
        void StopRun(){}
}
```

I couldn't decide on a nice way to give the plugins access to the various services like database access, events etc. Was hoping you could help me with that.
